### PR TITLE
Add papi auth to dev facade

### DIFF
--- a/dev_facade/RW/Core.py
+++ b/dev_facade/RW/Core.py
@@ -10,10 +10,14 @@ import requests
 from typing import Union, List
 from robot.libraries.BuiltIn import BuiltIn
 from RW import platform
+import logging
 
 import json
 import textwrap
 from collections import OrderedDict
+
+logger = logging.getLogger(__name__)
+
 
 class Core:
     """Core keyword library defines keywords used to access key platform features from robot code."""
@@ -43,9 +47,7 @@ class Core:
         self.builtin.set_suite_variable("${" + varname + "}", ret)
         return ret
 
-    def import_service(
-        self, varname: str, description: str = None, example: str = None, default: str = None, **kwargs
-    ):
+    def import_service(self, varname: str, description: str = None, example: str = None, default: str = None, **kwargs):
         """Creates an instance of rwplatform.Service for use by other keywords.
 
         Note that the description, example, default args are parsed in RunWhen static
@@ -167,8 +169,10 @@ class Core:
         odd (an error?) to have any metric/sub-metric called in more than one place per Suite,
         this doesn't seem like a constraint in practice.
         """
-        #Note that during local dev this simply logs to the console.
-        self.builtin.log_to_console(f"\nPush metric: value:{value} sub_name:{sub_name} metric_type:{metric_type} labels:{kwargs}\n")
+        # Note that during local dev this simply logs to the console.
+        self.builtin.log_to_console(
+            f"\nPush metric: value:{value} sub_name:{sub_name} metric_type:{metric_type} labels:{kwargs}\n"
+        )
 
     def task_failure(self, msg: str) -> None:
         """
@@ -387,6 +391,18 @@ class Core:
 
     def _datagrid_to_string(self, about, rows, columns) -> str:
         return self._json_to_string(rows)
+
+    def import_platform_variable(self, varname: str, *args, **kwargs) -> str:
+        """
+        Imports a variable set by the platform, making it available in the robot runtime
+        as a suite variable.
+        Raises ValueError if this isn't a valid platform variable name, or ImportError if not available.
+        :param str: Name to be used both to lookup the config val and for the
+            variable name in robot
+        :return: The value found
+        """
+        # in local dev, simply import from local environment
+        return self.import_user_variable(varname, *args, **kwargs)
 
     def shell(
         self,

--- a/dev_facade/RW/platform.py
+++ b/dev_facade/RW/platform.py
@@ -157,6 +157,7 @@ class TaskError(Error):
     or unexpected result.
     """
 
+
 def error_log(*msg, console: Union[bool, str] = False, if_true: Optional[str] = None) -> None:
     """
     Note: Error logs are automatically written to console.
@@ -229,6 +230,35 @@ def console_log(*msg) -> None:
 
 def console_log_if_true(condition: str, *msg) -> None:
     info_log(msg, console=True, if_true=condition)
+
+
+def form_access_token():
+    access_token = os.getenv("RW_ACCESS_TOKEN")
+    if not access_token:
+        doc_url = "https://docs.runwhen.com/public/platform-rest-api/getting-started-with-the-platform-rest-api"
+        raise Exception(
+            f"When doing local dev please refer to {doc_url} to set RW_ACCESS_TOKEN in your local environment variables"
+        )
+    return access_token
+
+
+def get_authenticated_session():
+    """Returns a request.session object authenticated to the RW public API using the
+    RW_ACCESS_TOKEN that should be available (either a user or service acct)
+    """
+    global session
+    if session:
+        return session
+    session = requests.Session()
+    access_token = form_access_token()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+    )
+    return session
 
 
 def execute_shell_command(


### PR DESCRIPTION
- Adds 2 methods to the devfacade for authenticating to papi
- This allows the papi keywords to function in devtools