### PR TITLE
Do not allow vscode to override img cmd

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,6 +2,7 @@
     "name": "devtools",
     "shutdownAction": "none",
     "image": "us-docker.pkg.dev/runwhen-nonprod-shared/public-images/codecollection-devtools:latest",
+    "overrideCommand": false,
     "extensions": [
         "robocorp.robotframework-lsp",
         "ms-python.pylint",


### PR DESCRIPTION
- Disables VSCode overwriting the image CMD or entrypoint